### PR TITLE
analytics: implement wallet-address based unique user tracking with M…

### DIFF
--- a/components/AnalyticsProvider.tsx
+++ b/components/AnalyticsProvider.tsx
@@ -23,7 +23,7 @@ interface AnalyticsProviderProps {
 
 export function AnalyticsProvider({ children }: AnalyticsProviderProps) {
   const { context, isFrameReady } = useMiniKit();
-  const { track, autoIdentify } = useAnalytics();
+  const { track } = useAnalytics();
 
   useEffect(() => {
     // Initialize Mixpanel when the component mounts
@@ -53,12 +53,7 @@ export function AnalyticsProvider({ children }: AnalyticsProviderProps) {
     }
   }, [isFrameReady, track, context]);
 
-  useEffect(() => {
-    // Auto-identify user when context becomes available
-    if (context && isAnalyticsEnabled()) {
-      autoIdentify();
-    }
-  }, [context, autoIdentify]);
+  // Identification is handled on wallet connect in WalletAnalytics.
 
   const contextValue: AnalyticsContextType = {
     isEnabled: isAnalyticsEnabled(),

--- a/components/WalletAnalytics.tsx
+++ b/components/WalletAnalytics.tsx
@@ -1,36 +1,59 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { useAccount } from "wagmi";
+import { useAccount, useChainId } from "wagmi";
 import { useAnalytics } from "@/lib/hooks/useAnalytics";
 import { EVENTS } from "@/lib/analytics";
+import { getAddress as checksum } from "viem";
 
 export function WalletAnalytics() {
-  const { isConnected, address } = useAccount();
+  const { isConnected, address, connector } = useAccount();
+  const chainId = useChainId();
   const prevConnected = useRef<boolean>(false);
   const prevAddress = useRef<string | undefined>(undefined);
-  const { trackWalletEvent } = useAnalytics();
+  const { trackWalletEvent, identify, register, reset } = useAnalytics();
 
   useEffect(() => {
     // Detect connect
     if (isConnected && address && (!prevConnected.current || prevAddress.current !== address)) {
+      const normalized = (() => {
+        try { return checksum(address as `0x${string}`); } catch { return address; }
+      })();
+      const providerName = connector?.name || 'unknown';
+
+      // Identify unique user by wallet address (EIP-55)
+      identify(normalized, {
+        wallet_address: normalized,
+        last_connected_chain_id: chainId,
+        wallet_provider: providerName,
+      });
+
+      // Register super properties applied to all events
+      register({
+        wallet_address: normalized,
+        chain_id: chainId,
+        wallet_provider: providerName,
+        network_env: 'testnet', // Base Sepolia
+      });
+
+      // Track connect event immediately to trigger ID merge
       trackWalletEvent(EVENTS.WALLET_CONNECTED, {
-        wallet_address: address,
-        connection_method: "coinbase_smart_wallet",
+        wallet_address: normalized,
+        connection_method: providerName?.toLowerCase().includes('coinbase') ? 'coinbase_smart_wallet' : 'external',
       });
     }
 
     // Detect disconnect
     if (!isConnected && prevConnected.current) {
       trackWalletEvent(EVENTS.WALLET_DISCONNECTED, {
-        connection_method: "coinbase_smart_wallet",
+        connection_method: 'coinbase_smart_wallet',
       });
+      reset(); // prevent identity bleed across users on same device
     }
 
     prevConnected.current = isConnected;
     prevAddress.current = address;
-  }, [isConnected, address, trackWalletEvent]);
+  }, [isConnected, address, chainId, connector, identify, register, reset, trackWalletEvent]);
 
   return null;
 }
-

--- a/lib/hooks/useAnalytics.ts
+++ b/lib/hooks/useAnalytics.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { useMiniKit } from '@coinbase/onchainkit/minikit';
-import { getMixpanel, isAnalyticsEnabled } from '@/lib/mixpanel';
+import { getMixpanel, isAnalyticsEnabled, registerSuperProperties, resetAnalytics } from '@/lib/mixpanel';
 import { 
   EventName, 
   DebateEventProperties, 
@@ -62,6 +62,23 @@ export const useAnalytics = () => {
     }
   }, [mixpanel]);
 
+  const register = useCallback((properties: Record<string, unknown>) => {
+    if (!isAnalyticsEnabled()) return;
+    try {
+      registerSuperProperties(properties);
+    } catch (error) {
+      console.error('Error registering super properties:', error);
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    try {
+      resetAnalytics();
+    } catch (error) {
+      console.error('Error resetting analytics:', error);
+    }
+  }, []);
+
   const setUserProperties = useCallback((properties: Record<string, unknown>) => {
     if (!isAnalyticsEnabled() || !mixpanel) {
       return;
@@ -116,21 +133,15 @@ export const useAnalytics = () => {
 
   // Auto-identify user if FID is available
   const autoIdentify = useCallback(() => {
-    if (context?.user?.fid) {
-      identify(context.user.fid.toString(), {
-        fid: context.user.fid,
-        username: context.user.username,
-        display_name: context.user.display_name,
-        pfp_url: context.user.pfp_url,
-        client_name: context.client?.name,
-        frame_added: context.client?.added
-      });
-    }
+    // Intentionally no-op for wallet-address identification strategy.
+    // Wallet identification occurs on connect in WalletAnalytics.
   }, [context, identify]);
 
   return {
     track,
     identify,
+    register,
+    reset,
     setUserProperties,
     trackDebateEvent,
     trackBetEvent,


### PR DESCRIPTION
…ixpanel

- mixpanel(init): persistence localStorage, autocapture:false, opt_out_by_default:true, optional api_host and ip:false; add consent helpers (optIn/optOut) and super property/register/reset helpers
- useAnalytics: expose register/reset; make autoIdentify a no-op (shift to wallet-based ID)
- WalletAnalytics: on connect, checksum address, identify(addr), register super props (wallet_address, chain_id, wallet_provider, network_env), then track WALLET_CONNECTED; on disconnect, track and reset
- AnalyticsProvider: keep lifecycle events, remove FID auto-identify to avoid  conflicts