### PR TITLE
docs(analytics): unify env var and update behavior

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,8 @@ Critical environment variables that must be set:
 - `NEXT_PUBLIC_ONCHAINKIT_API_KEY` - OnchainKit API access
 - `NEXT_PUBLIC_URL` - Application URL for frame metadata
 - `REDIS_URL` & `REDIS_TOKEN` - Upstash Redis connection (required for notifications)
- - `NEXT_PUBLIC_MIXPANEL_TOKEN` - Mixpanel project token for analytics (optional, analytics disabled if not set)
+ - `NEXT_PUBLIC_MIXPANEL_TOKEN` - Mixpanel project token for analytics (required to enable client events)
+ - `NEXT_PUBLIC_ANALYTICS_DEFAULT_OPT_IN` - Default client opt-in behavior. In development, analytics opt-in by default when a token is set. In production, analytics are opt-out by default unless the user has previously consented or this is set to `true`.
  - `MIXPANEL_TOKEN` - Server-side Mixpanel token (optional; falls back to NEXT_PUBLIC_MIXPANEL_TOKEN)
 - Frame metadata variables (`FARCASTER_*`) - Generated via `npx create-onchain --manifest`
 

--- a/README.md
+++ b/README.md
@@ -74,11 +74,20 @@ npm run dev
 
 ### Analytics (Mixpanel)
 
-Client-side analytics is initialized, but is disabled by default in development. To test events locally, add the following to `.env.local` and restart the dev server:
+Client-side analytics is initialized. Behavior by environment:
+- Development: default opt-in (events are tracked if a token is set).
+- Production: default opt-out unless the user has previously consented, or `NEXT_PUBLIC_ANALYTICS_DEFAULT_OPT_IN=true` is set.
+
+To test events locally, add a Mixpanel token to `.env.local` and restart the dev server:
 
 ```
-NEXT_PUBLIC_ENABLE_ANALYTICS_DEV=true
 NEXT_PUBLIC_MIXPANEL_TOKEN=YOUR_MIXPANEL_PROJECT_TOKEN
+```
+
+To opt-in by default in production (without per-user consent), set:
+
+```
+NEXT_PUBLIC_ANALYTICS_DEFAULT_OPT_IN=true
 ```
 
 For server-side webhook analytics (frame added/removed, notifications enabled/disabled), you can optionally set a server token:


### PR DESCRIPTION
- Standardize docs to use NEXT_PUBLIC_ANALYTICS_DEFAULT_OPT_IN\n- Correct development (opt-in) and production (opt-out unless consent or default opt-in) behavior description\n\nNote: Excludes committing .env to avoid exposing secrets.