### PR TITLE
Fix ENS CORS by adding mainnet RPC; harden end-notify POST

### DIFF
--- a/app/agreement/[id]/page.tsx
+++ b/app/agreement/[id]/page.tsx
@@ -544,6 +544,7 @@ export default function AgreementDetailPage() {
                 const urlBase = process.env.NEXT_PUBLIC_BACKEND_URL;
                 if (urlBase) {
                   const url = `${urlBase}/api/oracle/contracts/${contractId}/ended`;
+                  // Fire-and-forget with error handling; keepalive increases reliability during unload
                   void fetch(url, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
@@ -553,6 +554,16 @@ export default function AgreementDetailPage() {
                       bettingEndTime: Number(contract.bettingEndTime ?? 0),
                       chainId: baseSepolia.id,
                     }),
+                    cache: 'no-store',
+                    keepalive: true,
+                  })
+                  .then((res) => {
+                    if (!res.ok) {
+                      console.warn('Backend end-notify responded non-OK:', res.status, res.statusText);
+                    }
+                  })
+                  .catch((e) => {
+                    console.warn('Failed to notify backend about debate end', e);
                   });
                 }
               } catch (e) {

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -2,7 +2,7 @@
 
 import { type ReactNode } from "react";
 import { WagmiProvider, createConfig, http } from "wagmi";
-import { baseSepolia } from "wagmi/chains";
+import { baseSepolia, mainnet } from "wagmi/chains";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MiniKitProvider } from "@coinbase/onchainkit/minikit";
 import { OnchainKitProvider } from "@coinbase/onchainkit";
@@ -14,7 +14,8 @@ const queryClient = new QueryClient();
 
 // Configure wagmi with Coinbase Wallet connector
 const wagmiConfig = createConfig({
-  chains: [baseSepolia],
+  // Include Base Sepolia (app chain) and Ethereum Mainnet (ENS resolution)
+  chains: [baseSepolia, mainnet],
   connectors: [
     coinbaseWallet({
       appName: process.env.NEXT_PUBLIC_ONCHAINKIT_PROJECT_NAME || "Agora",
@@ -27,6 +28,11 @@ const wagmiConfig = createConfig({
   ],
   transports: {
     [baseSepolia.id]: http("https://sepolia.base.org"),
+    // Use a CORS-friendly public RPC for mainnet by default; allow override via env
+    [mainnet.id]: http(
+      process.env.NEXT_PUBLIC_MAINNET_RPC_URL ||
+        "https://rpc.ankr.com/eth"
+    ),
   },
   syncConnectedChain: true, // Force chain synchronization with wallet
   ssr: false,


### PR DESCRIPTION
This PR addresses client-side errors related to ENS lookups hitting Cloudflare Gateway (eth.merkle.io) and failing CORS, and improves reliability of the debate end notification.

Changes
- wagmi: add Ethereum mainnet chain + transport; default to https://rpc.ankr.com/eth; allow override via NEXT_PUBLIC_MAINNET_RPC_URL.
- providers: include mainnet in Wagmi config to ensure ENS resolution via a CORS-friendly RPC.
- agreement detail: add keepalive + no-store and error handling on end-of-bet POST to backend.

Notes
- .env.example locally updated to document NEXT_PUBLIC_MAINNET_RPC_URL, but it is ignored by .git per current .gitignore (.env*). If we want to track .env.example, we can adjust ignore rules in a follow-up.

Please review and merge into dev.